### PR TITLE
aa - JokeQueryService and JokeQueryServiceTests added

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -5,6 +5,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+// taken from example EarthquakeQueryService
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
+// taken from example EarthquakeQueryService
+import java.util.List;
+import java.util.Map;
+// taken from example EarthquakeQueryService
+@Slf4j
+
 
 @Service
 public class JokeQueryService {
@@ -15,9 +28,32 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
-        return "";
+        log.info("category={}, numJokes={}", category, numJokes);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of(
+            "category", category,
+            "numJokes", String.valueOf(numJokes)
+        );
+
+        ResponseEntity<String> re = restTemplate.exchange(
+            ENDPOINT, 
+            HttpMethod.GET, 
+            entity, 
+            String.class, 
+            uriVariables
+        );
+
+        return re.getBody();
+        // return "";
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService jokeQueryService; 
+
+    @Test
+    public void test_getJSON() {
+
+        String category = "Any";
+        int numJokes = 5;
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
+                .replace("{numJokes}", String.valueOf(numJokes));
+
+        String fakeJsonResult = "{ \"joke\" : \"This is a fake joke.\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add a service that wraps the Joke API from
https://v2.jokeapi.dev/joke/{category}?amount={numJokes}

Closes #6 